### PR TITLE
Add wildcard to AWS partition in ARN validation

### DIFF
--- a/templates/03_install_consul_config.sh.tpl
+++ b/templates/03_install_consul_config.sh.tpl
@@ -42,7 +42,7 @@ function retrieve_license_from_awssm {
   if [[ -z "$SECRET_ARN" ]]; then
     log "ERROR" "Secret ARN cannot be empty. Exiting."
     exit_script 4
-  elif [[ "$SECRET_ARN" == arn:aws:secretsmanager:* ]]; then
+  elif [[ "$SECRET_ARN" == arn:aws*:secretsmanager:* ]]; then
     log "INFO" "Retrieving value of secret '$SECRET_ARN' from AWS Secrets Manager."
     CONSUL_LICENSE=$(aws secretsmanager get-secret-value --region $SECRET_REGION --secret-id $SECRET_ARN --query SecretString --output text)
     echo "$CONSUL_LICENSE" > $CONSUL_LICENSE_PATH
@@ -65,7 +65,7 @@ function retrieve_certs_from_awssm {
   if [[ -z "$SECRET_ARN" ]]; then
     log "ERROR" "Secret ARN cannot be empty. Exiting."
     exit_script 5
-  elif [[ "$SECRET_ARN" == arn:aws:secretsmanager:* ]]; then
+  elif [[ "$SECRET_ARN" == arn:aws*:secretsmanager:* ]]; then
     log "INFO" "Retrieving value of secret '$SECRET_ARN' from AWS Secrets Manager."
     CERT_DATA=$(aws secretsmanager get-secret-value --region $SECRET_REGION --secret-id $SECRET_ARN --query SecretString --output text)
     echo "$CERT_DATA" | base64 -d > $DESTINATION_PATH


### PR DESCRIPTION
This PR updates ARN validation patterns to use wildcards for AWS partitions, allowing the module to work across different AWS partitions (aws, aws-us-gov, aws-cn, etc.).