### PR TITLE
docs(consul): align module docs with secrets flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ This module requires the following to already be in place in AWS:
 - An AWS account
 - A VPC with at least 3 availability zones
 - An S3 Bucket for snapshots
-- Certificates added to AWS Systems Manager (SSM)
-- Consul License added to AWS Systems Manager (SSM)
+- TLS certificate material and the Consul license stored in AWS Secrets Manager, with the corresponding secret ARNs passed to `consul_agent`
 - An AMI to launch ASG instances from
 - List of AWS subnet IDs for instance(s) to be deployed into
 - List of subnet IDs to provision internal NLB interfaces within (optional)
@@ -28,6 +27,8 @@ The `examples/amazonlinux-internal-nlb-development` folder uses public subnets a
 ## Docs
 
 Additional documentation for customization and usage can be found in the [docs](./docs/) folder.
+
+The module retrieves `consul_agent.license_text_arn`, `consul_agent.ca_cert_arn`, `consul_agent.agent_cert_arn`, and `consul_agent.agent_key_arn` from AWS Secrets Manager when those values are Secrets Manager ARNs. If a value is not a Secrets Manager ARN, the module writes the provided value directly to disk, but Secrets Manager is the intended and recommended workflow.
 
 ## Module support
 
@@ -113,8 +114,8 @@ Please note that there is no official Service Level Agreement (SLA) for support 
 | <a name="input_consul_install_version"></a> [consul\_install\_version](#input\_consul\_install\_version) | Version of Consul to install, eg. '1.19.0+ent' | `string` | `"1.19.2+ent"` | no |
 | <a name="input_consul_nodes"></a> [consul\_nodes](#input\_consul\_nodes) | Number of Consul nodes to deploy. | `number` | `3` | no |
 | <a name="input_disk_params"></a> [disk\_params](#input\_disk\_params) | Disk parameters to use for the cluster nodes' block devices. | <pre>object({<br/>    root = object({<br/>      volume_type = string,<br/>      volume_size = number,<br/>      iops        = number<br/>    }),<br/>    data = object({<br/>      volume_type = string,<br/>      volume_size = number,<br/>      iops        = number<br/>    })<br/>  })</pre> | <pre>{<br/>  "data": {<br/>    "iops": 5000,<br/>    "volume_size": 100,<br/>    "volume_type": "io1"<br/>  },<br/>  "root": {<br/>    "iops": 0,<br/>    "volume_size": 32,<br/>    "volume_type": "gp2"<br/>  }<br/>}</pre> | no |
-| <a name="input_ec2_ami_id"></a> [ec2\_ami\_id](#input\_ec2\_ami\_id) | Custom AMI ID for Boundary EC2 Launch Template. If specified, value of `os_distro` must coincide with this custom AMI OS distro. | `string` | `null` | no |
-| <a name="input_ec2_os_distro"></a> [ec2\_os\_distro](#input\_ec2\_os\_distro) | Linux OS distribution for Boundary EC2 instance. Choose from `amzn2`, `ubuntu`, `rhel`, `centos`. | `string` | `"ubuntu"` | no |
+| <a name="input_ec2_ami_id"></a> [ec2\_ami\_id](#input\_ec2\_ami\_id) | Custom AMI ID for Consul EC2 Launch Template. If specified, value of `os_distro` must coincide with this custom AMI OS distro. | `string` | `null` | no |
+| <a name="input_ec2_os_distro"></a> [ec2\_os\_distro](#input\_ec2\_os\_distro) | Linux OS distribution for Consul EC2 instance. Choose from `amzn2`, `ubuntu`, `rhel`, `centos`. | `string` | `"ubuntu"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type to launch. | `string` | `"m5.large"` | no |
 | <a name="input_permit_all_egress"></a> [permit\_all\_egress](#input\_permit\_all\_egress) | Whether broad (0.0.0.0/0) egress should be permitted on cluster nodes. If disabled, additional rules must be added to permit HTTP(S) and other necessary network access. | `bool` | `true` | no |
 | <a name="input_route53_resolver_pool"></a> [route53\_resolver\_pool](#input\_route53\_resolver\_pool) | Enable .consul domain resolution with Route53 | <pre>object({<br/>    enabled         = bool<br/>    override_domain = optional(string)<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |

--- a/docs/deployment-customizations.md
+++ b/docs/deployment-customizations.md
@@ -2,11 +2,11 @@
 
 ## TLS
 
-Certificates are provided at startup via cloud-init. Follow the example to structure your certificates correctly.
+Certificates are provided at startup via cloud-init. The module reads `consul_agent.ca_cert_arn`, `consul_agent.agent_cert_arn`, and `consul_agent.agent_key_arn` from AWS Secrets Manager when those values are Secrets Manager ARNs. If a value is not a Secrets Manager ARN, the module treats it as the literal base64-encoded certificate content. Follow the example to structure your certificates correctly.
 
 ## Adding a Consul license
 
-To see an example of how to automate the addition of your Consul license to SSM, place the license file in the example directory. The Terraform module will handle the rest.
+To see an example of how to automate the addition of your Consul license to AWS Secrets Manager, place the license file in the example directory. The example creates the secret and passes its ARN to the module. If `consul_agent.license_text_arn` is not a Secrets Manager ARN, the module treats the provided value as the literal license text.
 
 ## Customizing options with tf.autovars.tfvars
 

--- a/examples/amazonlinux-internal-nlb-consul-primary/variables.tf
+++ b/examples/amazonlinux-internal-nlb-consul-primary/variables.tf
@@ -132,7 +132,7 @@ variable "asg_extra_tags" {
 
 variable "ec2_os_distro" {
   type        = string
-  description = "Linux OS distribution for Boundary EC2 instance. Choose from `amzn2`, `ubuntu`, `rhel`, `centos`."
+  description = "Linux OS distribution for Consul EC2 instance. Choose from `amzn2`, `ubuntu`, `rhel`, `centos`."
   default     = "ubuntu"
 
   validation {
@@ -142,7 +142,7 @@ variable "ec2_os_distro" {
 }
 variable "ec2_ami_id" {
   type        = string
-  description = "Custom AMI ID for Boundary EC2 Launch Template. If specified, value of `os_distro` must coincide with this custom AMI OS distro."
+  description = "Custom AMI ID for Consul EC2 Launch Template. If specified, value of `os_distro` must coincide with this custom AMI OS distro."
   default     = null
 
   validation {

--- a/examples/ubuntu-internal-nlb-development/README.md
+++ b/examples/ubuntu-internal-nlb-development/README.md
@@ -2,7 +2,7 @@
 
 In this deployment the requirements are kept to a minimum and should provide an example of how resources are used but **not to be used in production**.
 
-Data sources are configured to find the default VPC in the current account and region and deploy to the public subnets. TLS certificates are generated via Terraform and an initial root token is also injected via cloud-init. TLS certificates are created with appropriate flags and are created and automatically added to SSM secrets.
+Data sources are configured to find the default VPC in the current account and region and deploy to the public subnets. TLS certificates are generated via Terraform and an initial root token is also injected via cloud-init. TLS certificates and the Consul license are created with appropriate flags and stored in AWS Secrets Manager before their ARNs are passed to the module.
 
 ## Usage
 

--- a/examples/ubuntu-internal-nlb-development/ssm.tf
+++ b/examples/ubuntu-internal-nlb-development/ssm.tf
@@ -15,12 +15,6 @@ resource "aws_secretsmanager_secret_version" "consul_license_text" {
   secret_id     = aws_secretsmanager_secret.consul_license_text.id
   secret_string = local.license_text
 }
-# resource "aws_ssm_parameter" "consul_license_text" {
-#   name  = "consul_license_text"
-#   type  = "SecureString"
-#   value = local.license_text
-#   # arn
-# }
 resource "aws_secretsmanager_secret" "consul_ca_cert" {
   name        = "consul_ca_cert"
   description = "consul_ca_cert"
@@ -32,12 +26,6 @@ resource "aws_secretsmanager_secret_version" "consul_ca_cert" {
   secret_id     = aws_secretsmanager_secret.consul_ca_cert.id
   secret_string = base64encode(tls_self_signed_cert.consul_ca.cert_pem)
 }
-# resource "aws_ssm_parameter" "consul_ca_cert" {
-#   name  = "consul_ca_cert"
-#   type  = "SecureString"
-#   value = tls_self_signed_cert.consul_ca.cert_pem
-#   # arn
-# }
 resource "aws_secretsmanager_secret" "consul_agent_cert" {
   name        = "consul_agent_cert"
   description = "consul_agent_cert"
@@ -49,12 +37,6 @@ resource "aws_secretsmanager_secret_version" "consul_agent_cert" {
   secret_id     = aws_secretsmanager_secret.consul_agent_cert.id
   secret_string = base64encode(tls_locally_signed_cert.server.cert_pem)
 }
-# resource "aws_ssm_parameter" "consul_agent_cert" {
-#   name  = "consul_agent_cert"
-#   type  = "SecureString"
-#   value = tls_locally_signed_cert.server.cert_pem
-#   # arn
-# }
 resource "aws_secretsmanager_secret" "consul_agent_key" {
   name        = "consul_agent_key"
   description = "consul_agent_key"
@@ -66,9 +48,3 @@ resource "aws_secretsmanager_secret_version" "consul_agent_key" {
   secret_id     = aws_secretsmanager_secret.consul_agent_key.id
   secret_string = base64encode(tls_private_key.server.private_key_pem)
 }
-# resource "aws_ssm_parameter" "consul_agent_key" {
-#   name  = "consul_agent_key"
-#   type  = "SecureString"
-#   value = tls_private_key.server.private_key_pem
-#   # arn
-# }

--- a/iam.tf
+++ b/iam.tf
@@ -58,7 +58,6 @@ data "aws_iam_policy_document" "consul_secrets" {
   statement {
     effect = "Allow"
     actions = [
-      "ssm:GetParameter",
       "secretsmanager:GetSecretValue"
     ]
     resources = [

--- a/templates/03_install_consul_config.sh.tpl
+++ b/templates/03_install_consul_config.sh.tpl
@@ -35,7 +35,7 @@ function exit_script {
   exit "$1"
 }
 
-function retrieve_license_from_awssm {
+function retrieve_license_value {
   local SECRET_ARN="$1"
   local SECRET_REGION=$AWS_REGION
 
@@ -54,9 +54,7 @@ function retrieve_license_from_awssm {
 }
 
 
-# aws ssm get-parameter --with-decryption --name \$\{license_path} --query "Parameter.Value" --output text > /etc/consul.d/consul.hclic
-
-function retrieve_certs_from_awssm {
+function retrieve_cert_value {
   local SECRET_ARN="$1"
   local DESTINATION_PATH="$2"
   local SECRET_REGION=$AWS_REGION
@@ -75,11 +73,6 @@ function retrieve_certs_from_awssm {
     echo "$CERT_DATA" | base64 -d > $DESTINATION_PATH
   fi
 }
-
-# aws ssm get-parameter --with-decryption --name \$\{ca_cert_path} --query "Parameter.Value" --output text > /etc/consul.d/tls/consul-ca.pem
-# aws ssm get-parameter --with-decryption --name \$\{agent_cert_path} --query "Parameter.Value" --output text > /etc/consul.d/tls/consul-cert.pem
-# aws ssm get-parameter --with-decryption --name \$\{agent_key_path} --query "Parameter.Value" --output text > /etc/consul.d/tls/consul-key.pem
-
 
 log "INFO" "Creating Consul configuration file at $CONSUL_CONFIG_DIR/consul.hcl"
 
@@ -217,14 +210,14 @@ tee $CONSUL_CONFIG_DIR/consul.env <<EOF
 EOF
 
 log "INFO" "Retrieving CONSUL license file..."
-retrieve_license_from_awssm "${license_text_arn}"
+retrieve_license_value "${license_text_arn}"
 
 log "INFO" "Retrieving CONSUL TLS certificate..."
-retrieve_certs_from_awssm "${agent_cert_arn}" "$CONSUL_TLS_CERTS_DIR/consul-cert.pem"
+retrieve_cert_value "${agent_cert_arn}" "$CONSUL_TLS_CERTS_DIR/consul-cert.pem"
 log "INFO" "Retrieving CONSUL TLS private key..."
-retrieve_certs_from_awssm "${agent_key_arn}" "$CONSUL_TLS_CERTS_DIR/consul-key.pem"
+retrieve_cert_value "${agent_key_arn}" "$CONSUL_TLS_CERTS_DIR/consul-key.pem"
 log "INFO" "Retrieving CONSUL TLS CA bundle..."
-retrieve_certs_from_awssm "${ca_cert_arn}" "$CONSUL_TLS_CERTS_DIR/consul-ca.pem"
+retrieve_cert_value "${ca_cert_arn}" "$CONSUL_TLS_CERTS_DIR/consul-ca.pem"
 
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,7 @@ variable "asg_extra_tags" {
 
 variable "ec2_os_distro" {
   type        = string
-  description = "Linux OS distribution for Boundary EC2 instance. Choose from `amzn2`, `ubuntu`, `rhel`, `centos`."
+  description = "Linux OS distribution for Consul EC2 instance. Choose from `amzn2`, `ubuntu`, `rhel`, `centos`."
   default     = "ubuntu"
 
   validation {
@@ -145,7 +145,7 @@ variable "ec2_os_distro" {
 }
 variable "ec2_ami_id" {
   type        = string
-  description = "Custom AMI ID for Boundary EC2 Launch Template. If specified, value of `os_distro` must coincide with this custom AMI OS distro."
+  description = "Custom AMI ID for Consul EC2 Launch Template. If specified, value of `os_distro` must coincide with this custom AMI OS distro."
   default     = null
 
   validation {


### PR DESCRIPTION
## Description
Align module documentation and secret handling references with the current Consul implementation.

- replace stale Boundary references with Consul in module variables and generated docs
- update README and docs to describe AWS Secrets Manager as the active secret source
- remove leftover SSM-oriented comments, example snippets, and IAM permission drift

## Related issue
N/A

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How has this been tested?
- Reviewed the module secret retrieval flow in `templates/03_install_consul_config.sh.tpl`, `iam.tf`, and the example configuration.
- Ran `terraform fmt -check=true -list=false variables.tf examples/amazonlinux-internal-nlb-consul-primary/variables.tf`
- Ran `terraform fmt -check=true -list=false iam.tf examples/ubuntu-internal-nlb-development/ssm.tf`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
The module currently supports literal inline values for secret inputs, but the documented and recommended path is AWS Secrets Manager via the `consul_agent.*_arn` inputs.
